### PR TITLE
Fixed bug in ComponentPresentationProvider: if 'SelectByOutputFormat'…

### DIFF
--- a/source/DD4T.Providers.SDLWeb8.CIL/Properties/AssemblyInfo.cs
+++ b/source/DD4T.Providers.SDLWeb8.CIL/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0-alpha1")]
+[assembly: AssemblyVersion("2.0.10.0")]
+[assembly: AssemblyFileVersion("2.0.10.0")]
+[assembly: AssemblyInformationalVersion("2.0.10-alpha1")]

--- a/source/DD4T.Providers.SDLWeb8.CIL/TridionComponentPresentationProvider.cs
+++ b/source/DD4T.Providers.SDLWeb8.CIL/TridionComponentPresentationProvider.cs
@@ -73,20 +73,12 @@ namespace DD4T.Providers.SDLWeb8.CIL
                     return cp.Content;
                 }
             }
-            LoggerService.Debug("GetContent: about to find all component presentations for {0}", LoggingCategory.Performance, tcmUri.ToString());
-            IList cps = cpFactory.FindAllComponentPresentations(tcmUri.ItemId);
-            LoggerService.Debug("GetContent: found all component presentations for {0}", LoggingCategory.Performance, tcmUri.ToString());
-
-            foreach (Tridion.ContentDelivery.DynamicContent.ComponentPresentation _cp in cps)
+            LoggerService.Debug("GetContent: about to get component presentations with Highst Priority for {0}", LoggingCategory.Performance, tcmUri.ToString());
+            cp = cpFactory.GetComponentPresentationWithHighestPriority(tcmUri.ItemId);
+            LoggerService.Debug("GetContent: get component presentations with Highst Priority for {0}", LoggingCategory.Performance, tcmUri.ToString());
+            if (cp != null)
             {
-                if (_cp != null)
-                {
-                    if (_cp.Content.Contains("<Component"))
-                    {
-                        LoggerService.Debug("<<GetContent({0}) - find all", LoggingCategory.Performance, uri);
-                        return _cp.Content;
-                    }
-                }
+                return cp.Content;
             }
             LoggerService.Debug("<<GetContent({0}) - not found", LoggingCategory.Performance, uri);
             return string.Empty;


### PR DESCRIPTION
… AND 'SelectByComponentTemplateId' were both not specified, no CPs were ever returned.
